### PR TITLE
Add shortcut for copying translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ For Firefox: [https://addons.mozilla.org/zh-TW/firefox/addon/google-translate-sh
 
 ## Keyboard shortcuts:
 * Alt + O = focus the input text
+* Alt + C = copy the output text
 * Alt + J = left audio button
 * Alt + K = right audio button
 * Alt + L = clear the input text

--- a/chrome/content.js
+++ b/chrome/content.js
@@ -27,6 +27,10 @@ window.onload = () => {
         orignalLang?.click();
     }
 
+    function copyOutputText() {
+        document.querySelector('[jsname="kImuFf"]').click();
+    }
+
     function init() {
         audioButtons = [document.querySelectorAll(audioSelector)[0], document.querySelectorAll(audioSelector)[1]]
         langButtons = Array.from(document.querySelectorAll('.VfPpkd-AznF2e-LUERP-vJ7A6b-OWXEXe-XuHpsb.VfPpkd-AznF2e-LUERP-vJ7A6b > .VfPpkd-AznF2e-LUERP-bN97Pc')).map(i => [...i.childNodes]).flat()
@@ -101,6 +105,10 @@ window.onload = () => {
 
             case 'm':
                 switchToOrignalLang();
+                break;
+
+            case 'c':
+                copyOutputText();
                 break;
         }
     }

--- a/firefox/content.js
+++ b/firefox/content.js
@@ -27,6 +27,10 @@
         orignalLang?.click();
     }
 
+    function copyOutputText() {
+        document.querySelector('[jsname="kImuFf"]').click();
+    }
+
     function init() {
         audioButtons = [document.querySelectorAll(audioSelector)[0], document.querySelectorAll(audioSelector)[1]]
         langButtons = Array.from(document.querySelectorAll('.VfPpkd-AznF2e-LUERP-vJ7A6b-OWXEXe-XuHpsb.VfPpkd-AznF2e-LUERP-vJ7A6b > .VfPpkd-AznF2e-LUERP-bN97Pc')).map(i => [...i.childNodes]).flat()
@@ -101,6 +105,10 @@
 
             case 'm':
                 switchToOrignalLang();
+                break;
+
+            case 'c':
+                copyOutputText();
                 break;
         }
     }


### PR DESCRIPTION
This plugin is useful and would benefit from having a shortcut for the _Copy translation_ button. I’ve included it in this pull request.